### PR TITLE
Update error handling in slack module

### DIFF
--- a/smib/slack/error.py
+++ b/smib/slack/error.py
@@ -12,9 +12,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-ERRORS_TO_IGNORE = [
-    BoltUnhandledRequestError
-]
+ERROR_STATUSES = {
+    BoltUnhandledRequestError: HTTPStatus.NOT_FOUND
+}
 
 
 def get_http_status_json_response(http_status: HTTPStatus, error: Exception, request: BoltRequest) -> dict:
@@ -50,9 +50,9 @@ def get_http_status_json_problem_response(http_status: HTTPStatus, error: Except
 
 
 def handle_errors(error, context, request, body):
-    if type(error) in ERRORS_TO_IGNORE:
-        logger.debug(f'Ignored error {error.__class__.__name__}: {error} for request {body}')
-        resp = BoltResponse(**get_http_status_json_response(HTTPStatus.OK, error, request))
+    if status := ERROR_STATUSES.get(error.__class__, None):
+        logger.debug(f'Pre-defined status code for error {error.__class__.__name__}: {error} for request {body}')
+        resp = BoltResponse(**get_http_status_json_response(status, error, request))
         context.ack()
         return resp
 

--- a/smib/slack/error.py
+++ b/smib/slack/error.py
@@ -50,13 +50,14 @@ def get_http_status_json_problem_response(http_status: HTTPStatus, error: Except
 
 
 def handle_errors(error, context, request, body):
-    if status := ERROR_STATUSES.get(error.__class__, None):
-        logger.debug(f'Pre-defined status code for error {error.__class__.__name__}: {error} for request {body}')
-        resp = BoltResponse(**get_http_status_json_response(status, error, request))
+    error_type = type(error)
+    if error_type in ERROR_STATUSES:
+        logger.debug(f'Pre-defined status code for error {error_type.__name__}: {error} for request {body}')
+        resp = BoltResponse(**get_http_status_json_response(ERROR_STATUSES.get(error_type), error, request))
         context.ack()
         return resp
 
-    logger.exception(f'Unexpected error {error.__class__.__name__}: {error}', exc_info=error)
+    logger.exception(f'Unexpected error {error_type.__name__}: {error}', exc_info=error)
     resp = BoltResponse(**get_http_status_json_problem_response(HTTPStatus.IM_A_TEAPOT, error, request))
     context.ack()
     return resp


### PR DESCRIPTION
Swapped from using a list "ERRORS_TO_IGNORE" to a dictionary "ERROR_STATUSES" to handle error types more flexibly in the Slack module. Now, instead of simply ignoring certain errors, they are associated with appropriate HTTP status codes in the new dictionary.

Any BoltUnhandledRequestError will now return a 404 
Any Unhandled Exception in a plugin will return a 418 (I'm a TEAPOT)