### PR TITLE
Add PUT method for events and http event listeners for space open and…

### DIFF
--- a/smib/slack/plugins/space/openclose/__init__.py
+++ b/smib/slack/plugins/space/openclose/__init__.py
@@ -44,6 +44,7 @@ def app_home_opened(client: WebClient, event: dict):
 
 
 @app.action('space_open')
+@app.event('http_put_space_open')
 def space_open(say, context, ack):
     ack()
     context['logger'].debug("Space Open!")
@@ -51,6 +52,7 @@ def space_open(say, context, ack):
 
 
 @app.action('space_closed')
+@app.event('http_put_space_closed')
 def space_closed(say, context, ack):
     ack()
     context['logger'].debug("Space Closed!")

--- a/smib/webserver/__main__.py
+++ b/smib/webserver/__main__.py
@@ -74,6 +74,7 @@ templates = Jinja2Templates(directory=str(WEBSERVER_TEMPLATES_DIRECTORY))
 
 @router.get('/event/{event}', tags=['SMIB Events'])
 @router.post('/event/{event}', tags=['SMIB Events'])
+@router.put('/event/{event}', tags=['SMIB Events'])
 async def smib_event_handler(request: Request, event: str):
     logger = inject("logger")
     logger.debug(f"Received event {event}")


### PR DESCRIPTION
… close

The change allows PUT method on '/event/{event}' route and adds 'http_put_space_open' and 'http_put_space_closed' event handlers improving functionality and increasing versatility. This enhancement facilitates specific HTTP requests to better manage operations regarding space opening and closing events.