### PR TITLE
Add manifest.yaml with bot configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
     environment:
       - WEBSERVER_HOST=smib-webserver
       - WEBSOCKET_ALLOWED_HOSTS=smib-webserver,smib-webserver.smib-bridge-network
+
+      - SLACK_APP_TOKEN
+      - SLACK_BOT_TOKEN
     networks:
       - smib-bridge-network
     command: "python -m smib.slack"
@@ -24,6 +27,9 @@ services:
       - smib-slack
     environment:
       - WEBSOCKET_HOST=smib-slack
+
+      - SLACK_APP_TOKEN
+      - SLACK_BOT_TOKEN
     networks:
       - smib-bridge-network
     command: "python -m smib.webserver"

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,7 +5,7 @@ display_information:
 features:
   app_home:
     home_tab_enabled: true
-    messages_tab_enabled: true
+    messages_tab_enabled: false
     messages_tab_read_only_enabled: false
   bot_user:
     display_name: SMIB
@@ -13,39 +13,12 @@ features:
 oauth_config:
   scopes:
     bot:
-      - app_mentions:read
-      - channels:history
-      - channels:read
       - chat:write
-      - chat:write.customize
       - chat:write.public
-      - groups:history
-      - groups:read
-      - im:history
-      - im:read
-      - im:write
-      - mpim:history
-      - mpim:read
-      - reactions:read
-      - users.profile:read
-      - users:read
 settings:
   event_subscriptions:
     bot_events:
       - app_home_opened
-      - channel_created
-      - channel_deleted
-      - channel_id_changed
-      - channel_rename
-      - member_joined_channel
-      - member_left_channel
-      - message.channels
-      - message.groups
-      - message.im
-      - message.mpim
-      - reaction_added
-      - reaction_removed
-      - team_join
   interactivity:
     is_enabled: true
   org_deploy_enabled: false

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,53 @@
+display_information:
+  name: S.M.I.B.
+  description: So Make It BOT
+  background_color: "#005056"
+features:
+  app_home:
+    home_tab_enabled: true
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
+  bot_user:
+    display_name: SMIB
+    always_online: true
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - channels:history
+      - channels:read
+      - chat:write
+      - chat:write.customize
+      - chat:write.public
+      - groups:history
+      - groups:read
+      - im:history
+      - im:read
+      - im:write
+      - mpim:history
+      - mpim:read
+      - reactions:read
+      - users.profile:read
+      - users:read
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_home_opened
+      - channel_created
+      - channel_deleted
+      - channel_id_changed
+      - channel_rename
+      - member_joined_channel
+      - member_left_channel
+      - message.channels
+      - message.groups
+      - message.im
+      - message.mpim
+      - reaction_added
+      - reaction_removed
+      - team_join
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false


### PR DESCRIPTION
Created a new `manifest.yaml` file, which defines the bot's configuration settings. This includes information like the bot's display name, oauth scopes, and event subscriptions. Also specifies some settings such as enabling interactivity and disabling organization deployment.