### PR TITLE
Update Python version in README and Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## Python Version
+Python 3.12.3
+
 ## Docker deployment
 ### Installation
 - Clone the repository to your target server host

--- a/smib-fast.Dockerfile
+++ b/smib-fast.Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python 3.11 runtime as a base image
-FROM python:3.11-buster as builder
+FROM python:3.12.3-bullseye as builder
 
 RUN pip install poetry==1.4.2
 
@@ -27,7 +27,7 @@ COPY pyproject.toml poetry.lock README.md ./
 RUN poetry install --without dev --no-root && rm -rf $POETRY_CACHE_DIR
 
 # The runtime image, used to just run the code provided its virtual environment
-FROM python:3.11-slim-buster as runtime
+FROM python:3.12.3-slim-bullseye as runtime
 
 ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
Updated the Python version to 3.12.3 in README.md and smib-fast.Dockerfile. The base image in Dockerfile was updated from 'python:3.11-buster' to 'python:3.12.3-bullseye' for builder and from 'python:3.11-slim-buster' to 'python:3.12.3-slim-bullseye' for runtime. The Python version in the README was also added to reflect these changes.