### PR TITLE
Add optional env file to git branch compose files

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -4,6 +4,9 @@ services:
     build:
       context: https://github.com/somakeit/smib.git#develop
       dockerfile: smib-fast.Dockerfile
+    env_file:
+      - path: .env
+        required: false
     ports:
       - "4123:4123"
     depends_on:
@@ -23,6 +26,9 @@ services:
     build:
       context: https://github.com/somakeit/smib.git#develop
       dockerfile: smib-fast.Dockerfile
+    env_file:
+      - path: .env
+        required: false
     ports:
       - "80:80"
     depends_on:

--- a/docker-compose-master.yml
+++ b/docker-compose-master.yml
@@ -4,6 +4,9 @@ services:
     build:
       context: https://github.com/somakeit/smib.git#master
       dockerfile: smib-fast.Dockerfile
+    env_file:
+      - path: .env
+        required: false
     ports:
       - "4123:4123"
     depends_on:
@@ -23,6 +26,9 @@ services:
     build:
       context: https://github.com/somakeit/smib.git#master
       dockerfile: smib-fast.Dockerfile
+    env_file:
+      - path: .env
+        required: false
     ports:
       - "80:80"
     depends_on:


### PR DESCRIPTION
Added to docker-compose-develop.yml and docker-compose-master.yml


This allows a .env to be specified locally (outside the GIT context). The .env file variables get injected into the container as per the BAU docker compose processing.

THis also still allows external config as per the README.MD