### PR TITLE
Add logging feature for space open/close events

### DIFF
--- a/smib/slack/plugins/space/smibhid/__init__.py
+++ b/smib/slack/plugins/space/smibhid/__init__.py
@@ -30,8 +30,6 @@ def on_smibhid_ui_log_post(event: dict, context: dict, ack: callable, request: B
     device_hostname, *_ = request.headers.get('device-hostname', None)
     device_ip = event['request']['ip']
 
-    logger.debug(pformat(event))
-
     data = event.get("data", [])
     if not data:
         logger.info("No logs received in request")

--- a/smib/slack/plugins/space/smibhid/__init__.py
+++ b/smib/slack/plugins/space/smibhid/__init__.py
@@ -1,0 +1,66 @@
+__plugin_name__ = "Space Open/Close"
+__description__ = "Space Open Close Button"
+__author__ = "Sam Cork"
+
+from datetime import datetime
+from logging import Logger
+from pprint import pformat
+
+from pydantic import ValidationError
+from injectable import inject
+
+from smib.slack.custom_app import CustomApp
+from smib.slack.db import database
+from mogo.connection import Connection
+from smib.common.utils import http_bolt_response
+from .models.api import UILogs as ApiUILogs, UILog as ApiUILog
+from .models.db import UILog as DbUILog
+
+from slack_bolt.request import BoltRequest
+
+app: CustomApp = inject("SlackApp")
+
+
+@app.event("http_post_smibhid_ui_log")
+@http_bolt_response
+def on_smibhid_ui_log_post(event: dict, context: dict, ack: callable, request: BoltRequest):
+    ack()
+    logger: Logger = context.get('logger')
+
+    device_hostname, *_ = request.headers.get('device-hostname', None)
+    device_ip = event['request']['ip']
+
+    logger.debug(pformat(event))
+
+    data = event.get("data", [])
+    if not data:
+        logger.info("No logs received in request")
+        return
+
+    logger.debug(pformat(data))
+
+    try:
+        ui_logs = ApiUILogs(ui_logs=data)
+        logger.debug(ui_logs)
+    except ValidationError as e:
+        logger.warning(e)
+        return 400, {}
+
+    save_api_logs_to_db(ui_logs, device_ip, device_hostname)
+
+
+@database()
+def save_api_logs_to_db(api_logs: ApiUILogs, device_ip: str, device_hostname: str | None):
+    for api_log in api_logs:
+        api_log: ApiUILog
+
+        db_log = DbUILog()
+
+        db_log.timestamp = datetime.utcfromtimestamp(api_log.timestamp)
+        db_log.type = api_log.type
+        db_log.event = api_log.event.dict()
+
+        db_log.device_hostname = device_hostname
+        db_log.device_ip = device_ip
+
+        db_log.save()

--- a/smib/slack/plugins/space/smibhid/models/api.py
+++ b/smib/slack/plugins/space/smibhid/models/api.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from typing import Literal
+
+
+class ButtonPressEvent(BaseModel):
+    button_name: str
+    button_id: str
+
+
+class UILog(BaseModel):
+    event: ButtonPressEvent
+    type: Literal['button_press', 'rotary_dial']
+    timestamp: int
+
+
+class UILogs(BaseModel):
+    ui_logs: list[UILog]
+
+    def __iter__(self):
+        yield from self.ui_logs
+
+
+

--- a/smib/slack/plugins/space/smibhid/models/db.py
+++ b/smib/slack/plugins/space/smibhid/models/db.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from typing import Any
+
+from smib.slack.db import Model, Field
+
+from pydantic import BaseModel
+
+
+class UILog(Model):
+    _name = "smibhid-ui-logs"
+
+    timestamp = Field[datetime](datetime)
+    type = Field[str](str, required=True)
+    event = Field[dict](dict, required=True)
+    device_hostname = Field[str](str)
+    device_ip = Field[str](str, required=True)

--- a/smib/slack/plugins/space/smibhid/tests/stub_log.py
+++ b/smib/slack/plugins/space/smibhid/tests/stub_log.py
@@ -1,0 +1,27 @@
+import json
+import time
+
+import requests
+
+
+def main():
+    data = [
+        {"event": {"button_name": "Space Open", "button_id": "space_open"}, "type": "button_press",
+         "timestamp": int(time.time())},
+        {"event": {"button_name": "Space Closed", "button_id": "space_closed"}, "type": "button_press",
+         "timestamp": int(time.time())},
+        {"event": {"button_name": "Space Open", "button_id": "space_open"}, "type": "button_press",
+         "timestamp": int(time.time())},
+        {"event": {"button_name": "Space Closed", "button_id": "space_closed"}, "type": "button_press",
+         "timestamp": int(time.time())}
+    ]
+    headers = {'device-hostname': "smibhid-dummy"}
+    url = f"http://localhost/smib/event/smibhid_ui_log"
+    print(url)
+    response = requests.post(url, headers=headers, data=json.dumps(data), verify=False)
+
+    print(response.status_code)
+
+
+if __name__ == '__main__':
+    main()

--- a/smib/slack/plugins/space/smibhid/tests/stub_log.py
+++ b/smib/slack/plugins/space/smibhid/tests/stub_log.py
@@ -17,7 +17,9 @@ def main():
     ]
     headers = {'device-hostname': "smibhid-dummy"}
     url = f"http://localhost/smib/event/smibhid_ui_log"
-    print(url)
+    print(f"url: {url}")
+    print(f"data: {data}")
+    print(f"JSON data: {json.dumps(data)}")
     response = requests.post(url, headers=headers, data=json.dumps(data), verify=False)
 
     print(response.status_code)

--- a/smib/slack/plugins/space/smibhid/tests/stub_log.py
+++ b/smib/slack/plugins/space/smibhid/tests/stub_log.py
@@ -15,9 +15,10 @@ def main():
         {"event": {"button_name": "Space Closed", "button_id": "space_closed"}, "type": "button_press",
          "timestamp": int(time.time())}
     ]
-    headers = {'device-hostname': "smibhid-dummy"}
+    headers = {"Content-Type": "application/json", 'device-hostname': "smibhid-dummy"}
     url = f"http://localhost/smib/event/smibhid_ui_log"
     print(f"url: {url}")
+    print(f"headers: {headers}")
     print(f"data: {data}")
     print(f"JSON data: {json.dumps(data)}")
     response = requests.post(url, headers=headers, data=json.dumps(data), verify=False)

--- a/smib/slack/plugins/space/smibhid/tests/stub_log.py
+++ b/smib/slack/plugins/space/smibhid/tests/stub_log.py
@@ -1,19 +1,22 @@
 import json
 import time
+from datetime import datetime, timezone
 
 import requests
 
 
 def main():
+    utc_time = datetime.now(timezone.utc)
+    utc_timestamp = int(utc_time.timestamp())
     data = [
         {"event": {"button_name": "Space Open", "button_id": "space_open"}, "type": "button_press",
-         "timestamp": int(time.time())},
+         "timestamp": utc_timestamp},
         {"event": {"button_name": "Space Closed", "button_id": "space_closed"}, "type": "button_press",
-         "timestamp": int(time.time())},
+         "timestamp": utc_timestamp},
         {"event": {"button_name": "Space Open", "button_id": "space_open"}, "type": "button_press",
-         "timestamp": int(time.time())},
+         "timestamp": utc_timestamp},
         {"event": {"button_name": "Space Closed", "button_id": "space_closed"}, "type": "button_press",
-         "timestamp": int(time.time())}
+         "timestamp": utc_timestamp}
     ]
     headers = {"Content-Type": "application/json", 'device-hostname': "smibhid-dummy"}
     url = f"http://localhost/smib/event/smibhid_ui_log"

--- a/smib/webserver/__main__.py
+++ b/smib/webserver/__main__.py
@@ -50,7 +50,6 @@ async def generate_request_body(fastapi_request):
 
 
 async def generate_bolt_request(fastapi_request: Request):
-    body = await fastapi_request.body()
     bolt_request: BoltRequest = to_bolt_request(fastapi_request, body=b'')
     bolt_request.body = await generate_request_body(fastapi_request)
     return bolt_request

--- a/smib/webserver/__main__.py
+++ b/smib/webserver/__main__.py
@@ -42,7 +42,8 @@ async def generate_request_body(fastapi_request):
                 "base_url": str(fastapi_request.base_url).rstrip('/') + str(fastapi_request.url.path),
                 "url": str(fastapi_request.url),
                 "parameters": dict(fastapi_request.query_params),
-                "headers": dict(filter(lambda item: is_pickleable(item), fastapi_request.headers.items()))
+                "headers": dict(filter(lambda item: is_pickleable(item), fastapi_request.headers.items())),
+                "ip": fastapi_request.scope["client"][0]
             }
         }
     }

--- a/smib/webserver/__main__.py
+++ b/smib/webserver/__main__.py
@@ -51,7 +51,7 @@ async def generate_request_body(fastapi_request):
 
 async def generate_bolt_request(fastapi_request: Request):
     body = await fastapi_request.body()
-    bolt_request: BoltRequest = to_bolt_request(fastapi_request, body=body)
+    bolt_request: BoltRequest = to_bolt_request(fastapi_request, body=b'')
     bolt_request.body = await generate_request_body(fastapi_request)
     return bolt_request
 

--- a/smibhid/config.py
+++ b/smibhid/config.py
@@ -22,6 +22,8 @@ WIFI_RETRY_BACKOFF_SECONDS = 5
 # Leave as none for MAC based unique hostname or specify a custom hostname string
 CUSTOM_HOSTNAME = None
 
+NTP_SYNC_INTERVAL_SECONDS = 86400
+
 ## Web host
 WEBSERVER_HOST = ""
 WEBSERVER_PORT = "80"

--- a/smibhid/lib/slack_api.py
+++ b/smibhid/lib/slack_api.py
@@ -38,7 +38,7 @@ class Wrapper:
     
     async def async_upload_ui_log(self, log: list) -> None:
         """Upload the UI log to the server."""
-        json_log = dumps({"log" : log})
+        json_log = dumps(log)
         await self._async_slack_api_request("POST", "smibhid_ui_log", json_log)
         
     async def _async_slack_api_request(self, method: str, url_suffix: str, json_data: str = "") -> dict:

--- a/smibhid/lib/space_state.py
+++ b/smibhid/lib/space_state.py
@@ -41,10 +41,10 @@ class SpaceState:
         self.space_open_button_event = Event()
         self.space_closed_button_event = Event()
         self.open_button = Button(
-            config.SPACE_OPEN_BUTTON, "Space_open", self.space_open_button_event
+            config.SPACE_OPEN_BUTTON, "Space Open", self.space_open_button_event
         )
         self.closed_button = Button(
-            config.SPACE_CLOSED_BUTTON, "Space_closed", self.space_closed_button_event
+            config.SPACE_CLOSED_BUTTON, "Space Closed", self.space_closed_button_event
         )
         self.space_open_led = StatusLED(config.SPACE_OPEN_LED)
         self.space_closed_led = StatusLED(config.SPACE_CLOSED_LED)

--- a/smibhid/lib/ulogging.py
+++ b/smibhid/lib/ulogging.py
@@ -1,5 +1,6 @@
 from gc import mem_free
 from os import stat, remove, rename
+from time import gmtime, time
 
 class uLogger:
     
@@ -57,7 +58,9 @@ class uLogger:
                 raise
 
     def decorate_message(self, message: str, level: str) -> str:
-        decorated_message = f"[Mem: {round(mem_free() / 1024)}kB free][{level}][{self.module_name}]: {message}"
+        time_str = gmtime(time())
+        timestamp = f"{time_str[0]}-{time_str[1]}-{time_str[2]} {time_str[3]}:{time_str[4]}:{time_str[5]}"
+        decorated_message = f"[{timestamp}][Mem: {round(mem_free() / 1024)}kB free][{level}][{self.module_name}]: {message}"
         return decorated_message
     
     def process_handlers(self, message: str) -> None:


### PR DESCRIPTION
Enable logging of button press events in Slack plugin for space open/close actions. This includes saving logs to the database and capturing client IP and hostname, along with a stub for testing log inputs.


Only tested with stubbed data (see tests subdirectory in new plugin)

Data gets logged to:
- Database:
 space_smibhid
- Collection:
 smibhid-ui-logs

