### PR TITLE
Mongo db env var fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Python 3.12.3
       - Set environment variable in a `.env` file thats alongside the `docker-compose-branch.yml` file
 
 
-### Configuration
+### SMIB Slack/Webserver Configuration
 
 #### Network Ports
 The host ports mapped for the slack server and webserver should be configured in the docker compose file, however it is also possible to override the ports in the server configs directly if you are not using docker.
@@ -76,6 +76,15 @@ Windows:
 volumes:
   - C:/smib/slack/logs:/app/logs/
 ```
+
+### Database and Database Web UI Configuration
+To set environment varaibles for the `smib-db` and `smib-db-ui` containers, you must do one of the following:
+  - `docker-compose` File - **Highest Precedence**
+    - Set the variables in your docker-compose file
+  - `.env` File
+    - Create a file called `.env` alongside the docker-compose.yml file. See links below for possible values
+      - [Database Web UI Configuration](https://github.com/mongo-express/mongo-express)
+      - [Database Configuration](https://hub.docker.com/_/mongo)
 
 ## SMIBHID
 [SMIBHID](smibhid/README.md) is the So Make It Bot Human Interface Device and definitely not a mispronunciation of any insults from a popular 90s documentary detailing the activites of the Jupiter Mining Core.

--- a/docker-compose-branch.yml
+++ b/docker-compose-branch.yml
@@ -68,7 +68,7 @@ services:
       - 8082:8081
     environment:
       ME_CONFIG_MONGODB_URL: mongodb://smib-db:27017/
-      ME_CONFIG_BASICAUTH: true
+      ME_CONFIG_BASICAUTH_ENABLED: true
       ME_CONFIG_OPTIONS_READONLY: true
 
     networks:

--- a/docker-compose-branch.yml
+++ b/docker-compose-branch.yml
@@ -47,6 +47,9 @@ services:
     image: mongo:4.4.18
     container_name: smib-db
     restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
     ports:
       - 27017:27017
     networks:
@@ -58,6 +61,9 @@ services:
     depends_on:
       - smib-db
     restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
     ports:
       - 8082:8081
     environment:

--- a/docker-compose-pi.yml
+++ b/docker-compose-pi.yml
@@ -69,7 +69,7 @@ services:
       - 8082:8081
     environment:
       ME_CONFIG_MONGODB_URL: mongodb://smib-db:27017/
-      ME_CONFIG_BASICAUTH: true
+      ME_CONFIG_BASICAUTH_ENABLED: true
       ME_CONFIG_OPTIONS_READONLY: true
 
     networks:

--- a/docker-compose-pi.yml
+++ b/docker-compose-pi.yml
@@ -48,6 +48,9 @@ services:
     image: mongo:4.4.18
     container_name: smib-db
     restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
     ports:
       - 27017:27017
     networks:
@@ -59,6 +62,9 @@ services:
     depends_on:
       - smib-db
     restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
     ports:
       - 8082:8081
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,9 @@ services:
     image: mongo:4.4.18
     container_name: smib-db
     restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
     ports:
       - 27017:27017
     networks:
@@ -52,6 +55,9 @@ services:
     depends_on:
       - smib-db
     restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
     ports:
       - 8082:8081
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - 8082:8081
     environment:
       ME_CONFIG_MONGODB_URL: mongodb://smib-db:27017/
-      ME_CONFIG_BASICAUTH: true
+      ME_CONFIG_BASICAUTH_ENABLED: true
       ME_CONFIG_OPTIONS_READONLY: true
 
     networks:

--- a/smib/webserver/__main__.py
+++ b/smib/webserver/__main__.py
@@ -161,7 +161,9 @@ def main(app: FastAPI, ws_handler: WebSocketHandler):
     try:
         import uvicorn
         logger.info(f"Starting WebServer v{get_version()}")
-        uvicorn.run(app, host=WEBSERVER_HOST, port=WEBSERVER_PORT, log_config=read_logging_json(), headers=[("server", APPLICATION_NAME)], proxy_headers=True)
+        uvicorn.run(app, host=WEBSERVER_HOST, port=WEBSERVER_PORT,
+                    log_config=read_logging_json(), headers=[("server", APPLICATION_NAME)], proxy_headers=True,
+                    forwarded_allow_ips="*")
     except KeyboardInterrupt:
         ...
     finally:

--- a/smib/webserver/__main__.py
+++ b/smib/webserver/__main__.py
@@ -161,9 +161,7 @@ def main(app: FastAPI, ws_handler: WebSocketHandler):
     try:
         import uvicorn
         logger.info(f"Starting WebServer v{get_version()}")
-        uvicorn.run(app, host=WEBSERVER_HOST, port=WEBSERVER_PORT,
-                    log_config=read_logging_json(), headers=[("server", APPLICATION_NAME)], proxy_headers=True,
-                    forwarded_allow_ips="*")
+        uvicorn.run(app, host=WEBSERVER_HOST, port=WEBSERVER_PORT, log_config=read_logging_json(), headers=[("server", APPLICATION_NAME)])
     except KeyboardInterrupt:
         ...
     finally:

--- a/smib/webserver/__main__.py
+++ b/smib/webserver/__main__.py
@@ -161,7 +161,7 @@ def main(app: FastAPI, ws_handler: WebSocketHandler):
     try:
         import uvicorn
         logger.info(f"Starting WebServer v{get_version()}")
-        uvicorn.run(app, host=WEBSERVER_HOST, port=WEBSERVER_PORT, log_config=read_logging_json(), headers=[("server", APPLICATION_NAME)])
+        uvicorn.run(app, host=WEBSERVER_HOST, port=WEBSERVER_PORT, log_config=read_logging_json(), headers=[("server", APPLICATION_NAME)], proxy_headers=True)
     except KeyboardInterrupt:
         ...
     finally:


### PR DESCRIPTION
fix to allow mongo db and mongo db ui environment variables to be overridden

Needs to be alongside the `docker-compose.yml` file.
example:
```.env
ME_CONFIG_BASICAUTH_USERNAME=root
ME_CONFIG_BASICAUTH_PASSWORD=example
```