### PR TITLE
Add MongoDB volume mappings in docker-compose-pi.yml

### DIFF
--- a/docker-compose-pi.yml
+++ b/docker-compose-pi.yml
@@ -53,6 +53,9 @@ services:
         required: false
     ports:
       - 27017:27017
+    volumes:
+      - /var/mongodb/db:/data/db
+      - /var/mongodb/configdb:/data/configdb
     networks:
       - smib-bridge-network
 


### PR DESCRIPTION
Previously, the MongoDB service in the Raspberry Pi setup lacked persistent storage configurations. This change ensures MongoDB data persists through container restarts by mapping host directories to container directories for both database and config data.

closes #224