### PR TITLE
Configure Renovate with weekend schedule and limits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,23 @@
 {
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "schedule": ["every weekend"],
+  "stabilityDays": 1,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["every weekend"]
+  },
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 2,
+  "dependencyDashboard": true,
+  "prCreation": "not-pending",
+  "autoclose": true,
+  "assignees": ["sam57719"],
+  "reviewers": ["sam57719"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["asyncio"],
+      "enabled": false
+    }
   ]
 }
+


### PR DESCRIPTION
- Set update schedule to every weekend
- Enable lock file maintenance on weekends
- Limit PRs to 2 per hour and 2 concurrent
- Enable dependency dashboard for easier tracking
- Auto-close stale PRs
- Assign and request review from sam57719 automatically
- Disable updates for 'asyncio' package (part of Python stdlib)
- Use 'not-pending' PR creation mode to reduce noise
- Extend from 'config:recommended' for sane defaults