### PR TITLE
Remove asyncio from dependancies - is already part of Python standard…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 
 dependencies = [
     "slack-bolt>=1.20.1,<2.0.0",
-    "asyncio>=3.4.3,<4.0.0",
     "uvicorn==0.35.0",
     "aiohttp (>=3.11.13,<4.0.0)",
     "makefun>=1.15.6,<2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -92,15 +92,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncio"
-version = "3.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/54/054bafaf2c0fb8473d423743e191fcdf49b2c1fd5e9af3524efbe097bafd/asyncio-3.4.3.tar.gz", hash = "sha256:83360ff8bc97980e4ff25c964c7bd3923d333d177aa4f7fb736b019f26c7cb41", size = 204411, upload-time = "2015-03-10T14:11:26.494Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/74/07679c5b9f98a7cb0fc147b1ef1cc1853bc07a4eb9cb5731e24732c5f773/asyncio-3.4.3-py3-none-any.whl", hash = "sha256:c4d18b22701821de07bd6aea8b53d21449ec0ec5680645e5317062ea21817d2d", size = 101767, upload-time = "2015-03-10T14:05:10.959Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -532,7 +523,6 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "apscheduler" },
-    { name = "asyncio" },
     { name = "beanie" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -550,7 +540,6 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.13,<4.0.0" },
     { name = "apscheduler", specifier = ">=3.11.0,<4.0.0" },
-    { name = "asyncio", specifier = ">=3.4.3,<4.0.0" },
     { name = "beanie", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "httpx", specifier = ">=0.28.1,<0.29.0" },


### PR DESCRIPTION
… library

closes #332 