### PR TITLE
313 space is temporarily closed functionality

### DIFF
--- a/src/plugins/space/spacestate/app_home.py
+++ b/src/plugins/space/spacestate/app_home.py
@@ -47,7 +47,12 @@ def _get_space_close_actions_block_elements() -> ActionsBlock:
         action_id="space_closed_button",
         style="danger"
     )
-    action_block = ActionsBlock(block_id="space_closed_block", elements=[closed_button])
+    minutes_static_select = StaticSelectElement(
+        action_id="space_closed_minutes_select",
+        placeholder=PlainTextObject(text="Select minutes (optional)", emoji=True),
+        options=[Option(value=f"{i}", text=f"{i}m") for i in range(0, 70, 10)],
+    )
+    action_block = ActionsBlock(block_id="space_closed_block", elements=[closed_button, minutes_static_select])
     return action_block
 
 
@@ -148,5 +153,11 @@ def _get_info_blocks() -> list[Block]:
 def extract_selected_hours_from_state(state: dict) -> int:
     try:
         return int(state["values"]["space_open_block"]["space_open_hours_select"]["selected_option"]["value"])
+    except (KeyError, TypeError, ValueError):
+        return 0
+
+def extract_selected_minutes_from_state(state: dict) -> int:
+    try:
+        return int(state["values"]["space_closed_block"]["space_closed_minutes_select"]["selected_option"]["value"])
     except (KeyError, TypeError, ValueError):
         return 0

--- a/src/plugins/space/spacestate/common.py
+++ b/src/plugins/space/spacestate/common.py
@@ -3,7 +3,7 @@ import logging
 from slack_bolt.context.say.async_say import AsyncSay
 
 from .config import config
-from .models import SpaceState, SpaceStateOpen, SpaceStateEnum, SpaceStateHistory
+from .models import SpaceState, SpaceStateOpen, SpaceStateEnum, SpaceStateHistory, SpaceStateClosed
 
 logger = logging.getLogger("Space State Plugin - Common")
 
@@ -30,8 +30,12 @@ async def send_space_open_announcement(say: AsyncSay, space_open_params: SpaceSt
 
     await say(message, channel=config.space_open_announce_channel_id)
 
-async def send_space_closed_announcement(say: AsyncSay) -> None:
-    await say("Space Closed!", channel=config.space_open_announce_channel_id)
+async def send_space_closed_announcement(say: AsyncSay, space_closed_params: SpaceStateClosed) -> None:
+    message = "Space Closed!"
+    if space_closed_params.minutes:
+        message = f"Space is temporarily closed (For about {space_closed_params.minutes}m)"
+
+    await say(message, channel=config.space_open_announce_channel_id)
 
 async def open_space(space_open_params: SpaceStateOpen, say: AsyncSay) -> None:
     new_state: SpaceStateEnum = SpaceStateEnum.OPEN
@@ -44,7 +48,7 @@ async def open_space(space_open_params: SpaceStateOpen, say: AsyncSay) -> None:
 
     await send_space_open_announcement(say, space_open_params)
 
-async def close_space(say: AsyncSay) -> None:
+async def close_space(space_closed_params: SpaceStateClosed, say: AsyncSay) -> None:
     new_state: SpaceStateEnum = SpaceStateEnum.CLOSED
     old_state: SpaceStateEnum = await get_space_state_enum_from_db()
 
@@ -53,4 +57,4 @@ async def close_space(say: AsyncSay) -> None:
         await set_space_state_in_db(new_state)
         await log_to_space_state_history(new_state)
 
-    await send_space_closed_announcement(say)
+    await send_space_closed_announcement(say, space_closed_params)

--- a/src/plugins/space/spacestate/listeners/http.py
+++ b/src/plugins/space/spacestate/listeners/http.py
@@ -1,6 +1,7 @@
 import logging
 from http import HTTPStatus
-from fastapi import Request
+from typing import Annotated
+from fastapi import Request, Body
 from slack_bolt.context.say.async_say import AsyncSay
 
 from smib.events.interfaces.http_event_interface import HttpEventInterface
@@ -13,16 +14,23 @@ logger = logging.getLogger("Space State Plugin - HTTP")
 def register(http: HttpEventInterface):
 
     @http.put("/space/state/open", status_code=HTTPStatus.NO_CONTENT)
-    async def set_space_open(say: AsyncSay, space_open_params: SpaceStateOpen) -> None:
+    async def set_space_open(
+        say: AsyncSay, 
+        space_open_params: Annotated[SpaceStateOpen | None, Body()] = None
+    ) -> None:
         """ Set the space state to open """
+        space_open_params = space_open_params or SpaceStateOpen()
         logger.info(f"Received space open request with {space_open_params.hours}h selected.")
         await open_space(space_open_params, say)
 
-
     @http.put("/space/state/closed", status_code=HTTPStatus.NO_CONTENT)
-    async def set_space_closed(say: AsyncSay, space_closed_params: SpaceStateClosed) -> None:
+    async def set_space_closed(
+        say: AsyncSay, 
+        space_closed_params: Annotated[SpaceStateClosed | None, Body()] = None
+    ) -> None:
         """ Set the space state to closed """
-        logger.info("Received space closed request.")
+        space_closed_params = space_closed_params or SpaceStateClosed()
+        logger.info(f"Received space closed request with {space_closed_params.minutes}m selected.")
         await close_space(space_closed_params, say)
 
 
@@ -36,14 +44,22 @@ def register(http: HttpEventInterface):
 
 
     @http.put("/smib/event/space_open", deprecated=True)
-    async def set_space_open_from_smib_event(say: AsyncSay, space_open_params: SpaceStateOpen) -> None:
+    async def set_space_open_from_smib_event(
+        say: AsyncSay, 
+        space_open_params: Annotated[SpaceStateOpen | None, Body()] = None
+    ) -> None:
         """ Set the space state to open """
+        space_open_params = space_open_params or SpaceStateOpen()
         logger.info(f"Received legacy space open request (deprecated) with {space_open_params.hours}h selected.")
         await open_space(space_open_params, say)
 
     @http.put("/smib/event/space_closed", deprecated=True)
-    async def set_space_closed_from_smib_event(say: AsyncSay, space_closed_params: SpaceStateClosed) -> None:
+    async def set_space_closed_from_smib_event(
+        say: AsyncSay, 
+        space_closed_params: Annotated[SpaceStateClosed | None, Body()] = None
+    ) -> None:
         """ Set the space state to closed """
+        space_closed_params = space_closed_params or SpaceStateClosed()
         logger.info("Received legacy space closed request (deprecated).")
         await close_space(space_closed_params, say)
 

--- a/src/plugins/space/spacestate/listeners/http.py
+++ b/src/plugins/space/spacestate/listeners/http.py
@@ -6,7 +6,7 @@ from slack_bolt.context.say.async_say import AsyncSay
 from smib.events.interfaces.http_event_interface import HttpEventInterface
 from ..common import set_space_state_in_db, send_space_open_announcement, send_space_closed_announcement, \
     get_space_state_from_db, open_space, close_space
-from ..models import SpaceState, SpaceStateEnum, SpaceStateOpen
+from ..models import SpaceState, SpaceStateEnum, SpaceStateOpen, SpaceStateClosed
 
 logger = logging.getLogger("Space State Plugin - HTTP")
 
@@ -20,10 +20,10 @@ def register(http: HttpEventInterface):
 
 
     @http.put("/space/state/closed", status_code=HTTPStatus.NO_CONTENT)
-    async def set_space_closed(say: AsyncSay) -> None:
+    async def set_space_closed(say: AsyncSay, space_closed_params: SpaceStateClosed) -> None:
         """ Set the space state to closed """
         logger.info("Received space closed request.")
-        await close_space(say)
+        await close_space(space_closed_params, say)
 
 
     @http.get("/space/state", response_model=SpaceState)
@@ -42,10 +42,10 @@ def register(http: HttpEventInterface):
         await open_space(space_open_params, say)
 
     @http.put("/smib/event/space_closed", deprecated=True)
-    async def set_space_closed_from_smib_event(say: AsyncSay) -> None:
+    async def set_space_closed_from_smib_event(say: AsyncSay, space_closed_params: SpaceStateClosed) -> None:
         """ Set the space state to closed """
         logger.info("Received legacy space closed request (deprecated).")
-        await close_space(say)
+        await close_space(space_closed_params, say)
 
     @http.get("/smib/event/space_state", deprecated=True)
     async def get_space_state_from_smib_event(say: AsyncSay) -> SpaceState:

--- a/src/plugins/space/spacestate/listeners/slack.py
+++ b/src/plugins/space/spacestate/listeners/slack.py
@@ -1,16 +1,15 @@
 import logging
 import re
-from pprint import pformat
 
 from slack_bolt.app.async_app import AsyncApp
 from slack_bolt.context.ack.async_ack import AsyncAck
 from slack_bolt.context.say.async_say import AsyncSay
 from slack_sdk.web.async_client import AsyncWebClient
 
-from ..app_home import get_app_home, extract_selected_hours_from_state
-from ..common import set_space_state_in_db, send_space_open_announcement, send_space_closed_announcement, open_space, \
+from ..app_home import get_app_home, extract_selected_hours_from_state, extract_selected_minutes_from_state
+from ..common import open_space, \
     close_space
-from ..models import SpaceStateEnum, SpaceStateOpen
+from ..models import SpaceStateOpen, SpaceStateClosed
 
 logger = logging.getLogger("Space State Plugin - Slack")
 
@@ -34,12 +33,18 @@ def register(slack: AsyncApp):
     async def handle_space_close_button_clicks(ack: AsyncAck, body: dict, context: dict, client: AsyncWebClient, say: AsyncSay):
         await ack()
 
+        params = SpaceStateClosed(minutes=extract_selected_minutes_from_state(body['view']['state']))
+
         logger.info(f"Space Closed Button clicked by {body['user']['name']} ({body['user']['id']})")
 
-        await close_space(say)
+        await close_space(params, say)
         await client.views_publish(user_id=context['user_id'], view=await get_app_home())
 
     @slack.action("space_open_hours_select")
+    async def handle_space_open_hours_select(ack: AsyncAck):
+        await ack()
+
+    @slack.action("space_closed_minutes_select")
     async def handle_space_open_hours_select(ack: AsyncAck):
         await ack()
 

--- a/src/plugins/space/spacestate/models.py
+++ b/src/plugins/space/spacestate/models.py
@@ -29,3 +29,6 @@ class SpaceStateHistory(Document):
 
 class SpaceStateOpen(BaseModel):
     hours: Annotated[int | None, Field(gt=-1, default=None, description="How many hours the space is open for?")]
+
+class SpaceStateClosed(BaseModel):
+    minutes: Annotated[int | None, Field(gt=-1, default=None, description="How many minutes the space is temporarily closed for?")]


### PR DESCRIPTION
Adds temporarily close space functionality to the api and slack app home.

The `/space/open` and `/space/closed` and the 2 deprecated versions of those endpoints now have an optional body. If the body is not provided, it defaults the hours/minutes to None/0. 