### PR TITLE
Explicitly enable dependency managers in renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,5 +30,6 @@
       ],
       "enabled": false
     }
-  ]
+  ],
+  "enabledManagers": ["pep621", "dockerfile", "docker-compose"]
 }


### PR DESCRIPTION
closes #345 