### PR TITLE
322 validate config on initialisation

### DIFF
--- a/src/smib/config/__init__.py
+++ b/src/smib/config/__init__.py
@@ -1,4 +1,13 @@
 import logging as logging_lib
+import sys
+from typing import Any, Dict, List, Tuple
+
+from pydantic import BaseModel
+
+from pydantic import ValidationError
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+
 from smib.config.general import GeneralSettings
 from smib.config.logging_ import LoggingSettings
 from smib.config.project import ProjectSettings
@@ -7,23 +16,101 @@ from smib.config.database import DatabaseSettings
 from smib.config.webserver import WebserverSettings
 from smib.config._env_base_settings import EnvBaseSettings
 
-__all__ = ["logging", "project", "general", "slack", "database", "webserver", "EnvBaseSettings"]
-
 from smib.logging_ import initialise_logging
+
+__all__ = [
+    "logging",
+    "project",
+    "general",
+    "slack",
+    "database",
+    "webserver",
+    "EnvBaseSettings",
+]
 
 _logger = logging_lib.getLogger(__name__)
 
+
+def _format_validation_errors(collected: list[tuple[BaseModel, ValidationError]]) -> str:
+    message_lines: list[str] = []
+    for model, validation_errors in collected:
+        model_config = model.model_config
+        env_var_prefix = model_config.get('env_prefix', '')
+
+        message_lines.append(f"Validation error for {model.__name__}:")
+        for error in validation_errors.errors():
+            field_name = error["loc"][0]
+            field: FieldInfo = model.model_fields[field_name]
+            error_message = error["msg"]
+            provided_value = error["input"]
+
+            message_lines.append(f"\t• {field_name}:")
+
+            spacing = 30
+            message_lines.append(f"\t\t{"Error:":<{spacing}} {error_message}")
+            message_lines.append(f"\t\t{"Provided Value:":<{spacing}} {provided_value}")
+
+            if field.description:
+                message_lines.append(f"\t\t{"Setting Description:":<{spacing}} {field.description}")
+
+            message_lines.append(f"\t\t{"Setting Environment Variable:":<{spacing}} {env_var_prefix}{field_name.upper()}")
+
+            message_lines.append(f"\t\t{"Setting Type:":<{spacing}} {field.annotation.__name__}")
+            if field.default != PydanticUndefined:
+                message_lines.append(f"\t\t{"Setting Default:":<{spacing}} {field.default}")
+
+    return "\n".join(["He's dead, Jim 🖖"] + message_lines)
+
+# Attempt to initialise all settings immediately (import-time), but with
+# clear, user-friendly validation reporting and fail-fast behaviour.
+_collected_errors: List[Tuple[type[BaseModel] | None, ValidationError]] = []
+
+logging: LoggingSettings | None = None
 try:
     logging = LoggingSettings()
     initialise_logging(logging.log_level)
+    _logger = logging_lib.getLogger(__name__)
+except ValidationError as ve:
+    _collected_errors.append((LoggingSettings, ve))
 
+project: ProjectSettings | None = None
+general: GeneralSettings | None = None
+slack: SlackSettings | None = None
+database: DatabaseSettings | None = None
+webserver: WebserverSettings | None = None
+
+try:
     project = ProjectSettings()
+except ValidationError as ve:
+    _collected_errors.append((ProjectSettings, ve))
+
+try:
     general = GeneralSettings()
+except ValidationError as ve:
+    _collected_errors.append((GeneralSettings, ve))
+
+try:
     slack = SlackSettings()
+except ValidationError as ve:
+    _collected_errors.append((SlackSettings, ve))
+
+try:
     database = DatabaseSettings()
+except ValidationError as ve:
+    _collected_errors.append((DatabaseSettings, ve))
+
+try:
     webserver = WebserverSettings()
-except Exception as e:
-    _logger.exception(repr(e), exc_info=e)
+except ValidationError as ve:
+    _collected_errors.append((WebserverSettings, ve))
+
+if _collected_errors:
+    # Prefer printing to stderr to ensure visibility even if logging isn't configured yet
+    msg = _format_validation_errors(_collected_errors)
+    # Print to stderr only to avoid duplicate outputs (some environments route logs to stderr too)
+    _logger.error(msg)
+    # Exit early so the application clearly stops on config errors
+    raise SystemExit(1)
 else:
     _logger.debug(f"Logging Settings Initialised:\n{logging.model_dump_json(indent=2)}")
     _logger.debug(f"Project Settings Initialised:\n{project.model_dump_json(indent=2)}")

--- a/src/smib/config/__init__.py
+++ b/src/smib/config/__init__.py
@@ -1,6 +1,5 @@
 import logging as logging_lib
 import sys
-from ftplib import error_temp
 from typing import Any, Dict, List, Tuple
 
 from pydantic import BaseModel

--- a/src/smib/config/__init__.py
+++ b/src/smib/config/__init__.py
@@ -1,5 +1,6 @@
 import logging as logging_lib
 import sys
+from ftplib import error_temp
 from typing import Any, Dict, List, Tuple
 
 from pydantic import BaseModel
@@ -42,13 +43,15 @@ def _format_validation_errors(collected: list[tuple[BaseModel, ValidationError]]
             field_name = error["loc"][0]
             field: FieldInfo = model.model_fields[field_name]
             error_message = error["msg"]
+            error_type = error["type"]
             provided_value = error["input"]
 
             message_lines.append(f"\t• {field_name}:")
 
             spacing = 30
             message_lines.append(f"\t\t{"Error:":<{spacing}} {error_message}")
-            message_lines.append(f"\t\t{"Provided Value:":<{spacing}} {provided_value}")
+            if error_type != 'missing' and provided_value != PydanticUndefined:
+                message_lines.append(f"\t\t{"Provided Value:":<{spacing}} {provided_value}")
 
             if field.description:
                 message_lines.append(f"\t\t{"Setting Description:":<{spacing}} {field.description}")

--- a/src/smib/config/__init__.py
+++ b/src/smib/config/__init__.py
@@ -57,7 +57,7 @@ def _format_validation_errors(collected: list[tuple[BaseModel, ValidationError]]
 
             message_lines.append(f"\t\t{"Setting Environment Variable:":<{spacing}} {env_var_prefix}{field_name.upper()}")
 
-            message_lines.append(f"\t\t{"Setting Type:":<{spacing}} {field.annotation.__name__}")
+            message_lines.append(f"\t\t{"Setting Type:":<{spacing}} {getattr(field.annotation, '__name__', str(field.annotation))}")
             if field.default != PydanticUndefined:
                 message_lines.append(f"\t\t{"Setting Default:":<{spacing}} {field.default}")
 

--- a/src/smib/config/__init__.py
+++ b/src/smib/config/__init__.py
@@ -65,7 +65,7 @@ def _format_validation_errors(collected: list[tuple[BaseModel, ValidationError]]
 
 # Attempt to initialise all settings immediately (import-time), but with
 # clear, user-friendly validation reporting and fail-fast behaviour.
-_collected_errors: List[Tuple[type[BaseModel] | None, ValidationError]] = []
+_collected_errors: list[tuple[BaseModel, ValidationError]] = []
 
 logging: LoggingSettings | None = None
 try:

--- a/src/smib/config/slack.py
+++ b/src/smib/config/slack.py
@@ -1,10 +1,10 @@
 import secrets
-from pathlib import Path
+from typing import ClassVar
 
-from pydantic import computed_field, SecretStr, Field
+from pydantic import SecretStr, Field, field_validator
 
 from ._env_base_settings import EnvBaseSettings
-from .project import ProjectSettings
+
 
 class SlackSettings(EnvBaseSettings):
     bot_token: SecretStr = Field(
@@ -18,7 +18,31 @@ class SlackSettings(EnvBaseSettings):
         description="Secret used to verify requests from Slack"
     )
 
+    _BOT_TOKEN_PREFIX: ClassVar[str] = "xoxb-"
+    _APP_TOKEN_PREFIX: ClassVar[str] = "xapp-"
 
+    @staticmethod
+    def _get_str(v):
+        return v.get_secret_value() if isinstance(v, SecretStr) else v
+
+    @staticmethod
+    def _validate_prefix(value, prefix: str, kind: str):
+        s = SlackSettings._get_str(value)
+        if not isinstance(s, str):
+            return value
+        if not s.startswith(prefix):
+            raise ValueError(f"Invalid Slack {kind} format (expected prefix {prefix})")
+        return value
+
+    @field_validator("bot_token", mode="before")
+    @classmethod
+    def validate_bot_token(cls, v):
+        return cls._validate_prefix(v, cls._BOT_TOKEN_PREFIX, "bot token")
+
+    @field_validator("app_token", mode="before")
+    @classmethod
+    def validate_app_token(cls, v):
+        return cls._validate_prefix(v, cls._APP_TOKEN_PREFIX, "app token")
 
     model_config = {
         "env_prefix": "SMIB_SLACK_"


### PR DESCRIPTION
The config that is used by the Python app is now validated and rejected upfront if there are any errors. 
This is all ENV VARS starting with `SMIB_` apart from `SMIB_PROXY_` and `SMIB_COMPOSE_`.

Errors are formatted nicely with useful information.

Closes #322 
