### PR TITLE
Version Management Refactor: Environment-Aware Version Display

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -10,6 +10,12 @@ This document provides a comprehensive overview of all configurable settings in 
 | SMIB_SLACK_APP_TOKEN | Slack app token used for socket mode connections | `xapp-1-A1234567890-1234567890123-abcdefghijklmnopqrstuvwxyz1234567890123456789012` | None (Required) |
 | SMIB_SLACK_SIGNING_SECRET | Secret used to verify requests from Slack | `abcdef1234567890abcdef1234567890` | Random generated string |
 
+## Environment Settings
+
+| Environment Variable      | Description                                                    | Example       | Default |
+|---------------------------|----------------------------------------------------------------|---------------|---------|
+| SMIB_ENVIRONMENT          | The application environment (PRODUCTION, TESTING, DEVELOPMENT) | `DEVELOPMENT` | `PRODUCTION` |
+
 ## Database Settings
 
 | Environment Variable | Description | Example | Default |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pydantic-settings>=2.11.0",
     "jinja2>=3.1.6",
     "websockets>=15.0.1",
+    "packaging>=25.0",
 ]
 
 dynamic = ["version"]
@@ -48,6 +49,7 @@ source = "vcs"
 
 [tool.hatch.version.raw-options]
 version_scheme = "no-guess-dev"
+local_scheme = "node-and-timestamp"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/smib"]

--- a/src/plugins/core/core/__init__.py
+++ b/src/plugins/core/core/__init__.py
@@ -13,7 +13,7 @@ def register(api: ApiEventInterface, database: DatabaseManager):
     @api.get("/version")
     async def get_version() -> Versions:
         return Versions(
-            smib=project.version,
+            smib=str(project.version),
             mongo=await database.get_db_version()
         )
 

--- a/src/plugins/core/docs/api_docs.py
+++ b/src/plugins/core/docs/api_docs.py
@@ -31,7 +31,7 @@ def register(web: WebEventInterface):
             return fastapi_app.openapi_schema
         openapi_schema = get_openapi(
             title=project.display_name,
-            version=project.version,
+            version=str(project.version),
             description=project.description,
             routes=fastapi_app.routes,
             tags=fastapi_app.openapi_tags

--- a/src/plugins/core/docs/db_docs.py
+++ b/src/plugins/core/docs/db_docs.py
@@ -87,7 +87,7 @@ def create_dummy_app() -> FastAPI:
     """Create a dummy FastAPI app for generating OpenAPI schema."""
     return FastAPI(
         title=f"{project.display_name} - Database Docs",
-        version=project.version,
+        version=str(project.version),
         description="This is the database schema documentation. The database is a Mongo DB instance.",
         openapi_url="/database/openapi.json",
         docs_url=None,

--- a/src/smib/config/__init__.py
+++ b/src/smib/config/__init__.py
@@ -2,12 +2,13 @@ import logging as logging_lib
 
 from smib.config._env_base_settings import EnvBaseSettings
 from smib.config._types import IntervalField, BaseSettings_T, CollectedErrors_T
-from smib.config.utils import format_validation_errors, init_settings
 from smib.config.database import DatabaseSettings
+from smib.config.environment import EnvironmentSettings
 from smib.config.general import GeneralSettings
 from smib.config.logging_ import LoggingSettings
 from smib.config.project import ProjectSettings
 from smib.config.slack import SlackSettings
+from smib.config.utils import format_validation_errors, init_settings
 from smib.config.webserver import WebserverSettings
 from smib.logging_ import initialise_logging
 from smib.utilities import split_camel_case
@@ -19,6 +20,7 @@ __all__ = [
     "slack",
     "database",
     "webserver",
+    "environment",
     "EnvBaseSettings",
     "IntervalField",
     "format_validation_errors",
@@ -37,6 +39,7 @@ if logging is not None:
     initialise_logging(logging.log_level)
     _logger = logging_lib.getLogger(__name__)
 
+environment: EnvironmentSettings | None = init_settings(EnvironmentSettings, _collected_errors)
 project: ProjectSettings | None = init_settings(ProjectSettings, _collected_errors)
 general: GeneralSettings | None = init_settings(GeneralSettings, _collected_errors)
 slack: SlackSettings | None = init_settings(SlackSettings, _collected_errors)
@@ -50,5 +53,5 @@ if _collected_errors:
     # Exit early so the application clearly stops on config errors
     raise SystemExit(1)
 else:
-    for setting in [logging, project, general, slack, database, webserver]:
+    for setting in [logging, environment, project, general, slack, database, webserver]:
         _logger.debug(f"{" ".join(split_camel_case(setting.__class__.__name__))} Initialised:\n{setting.model_dump_json(indent=2)}")

--- a/src/smib/config/environment.py
+++ b/src/smib/config/environment.py
@@ -1,17 +1,24 @@
 from enum import StrEnum
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from ._env_base_settings import EnvBaseSettings
 
 
 class Environment(StrEnum):
-    DEVELOPMENT = "development"
-    PRODUCTION = "production"
-    TESTING = "testing"
+    DEVELOPMENT = "DEVELOPMENT"
+    PRODUCTION = "PRODUCTION"
+    TESTING = "TESTING"
 
 class EnvironmentSettings(EnvBaseSettings):
     environment: Environment = Field(
         Environment.PRODUCTION,
         description="The application environment.",
     )
+
+    @field_validator("environment", mode="before")
+    @classmethod
+    def normalize_log_level(cls, v: str) -> str:
+        if isinstance(v, str):
+            return v.upper()
+        return v

--- a/src/smib/config/environment.py
+++ b/src/smib/config/environment.py
@@ -13,7 +13,7 @@ class Environment(StrEnum):
 class EnvironmentSettings(EnvBaseSettings):
     environment: Environment = Field(
         Environment.PRODUCTION,
-        description="The application environment.",
+        description="The application environment",
     )
 
     @field_validator("environment", mode="before")

--- a/src/smib/config/environment.py
+++ b/src/smib/config/environment.py
@@ -1,0 +1,17 @@
+from enum import StrEnum
+
+from pydantic import Field
+
+from ._env_base_settings import EnvBaseSettings
+
+
+class Environment(StrEnum):
+    DEVELOPMENT = "development"
+    PRODUCTION = "production"
+    TESTING = "testing"
+
+class EnvironmentSettings(EnvBaseSettings):
+    environment: Environment = Field(
+        Environment.PRODUCTION,
+        description="The application environment.",
+    )

--- a/src/smib/config/general.py
+++ b/src/smib/config/general.py
@@ -1,12 +1,14 @@
+from functools import cached_property
 from pathlib import Path
 
-from pydantic import computed_field, Field
+from pydantic import computed_field
 
 from ._env_base_settings import EnvBaseSettings
 from .project import ProjectSettings
 
+
 class GeneralSettings(EnvBaseSettings):
     @computed_field
-    @property
+    @cached_property
     def plugins_directory(self) -> Path:
         return ProjectSettings().package_root.parent / "plugins"

--- a/src/smib/config/utils.py
+++ b/src/smib/config/utils.py
@@ -17,6 +17,7 @@ def format_validation_errors(collected: CollectedErrors_T) -> str:
 
         message_lines.append(f"Validation error for {model.__name__}:")
         for error in validation_errors.errors():
+            print(error)
             field_name = error["loc"][0]
             field: FieldInfo = model.model_fields[field_name]
             error_message = error["msg"]

--- a/src/smib/config/utils.py
+++ b/src/smib/config/utils.py
@@ -17,7 +17,6 @@ def format_validation_errors(collected: CollectedErrors_T) -> str:
 
         message_lines.append(f"Validation error for {model.__name__}:")
         for error in validation_errors.errors():
-            print(error)
             field_name = error["loc"][0]
             field: FieldInfo = model.model_fields[field_name]
             error_message = error["msg"]

--- a/src/smib/events/services/http_event_service.py
+++ b/src/smib/events/services/http_event_service.py
@@ -28,7 +28,7 @@ class HttpEventService:
             root_path=root_path,
             root_path_in_servers=bool(root_path),
         )
-        self.logger.debug(f"FastAPI app: {pformat(app.__dict__)}")
+        self.logger.debug(f"FastAPI app:\n{pformat(app.__dict__)}")
         return app
 
     @property
@@ -41,10 +41,9 @@ class HttpEventService:
             forwarded_allow_ips=webserver.forwarded_allow_ips,
             headers=self.headers,
             log_config=get_logging_config(logging_config.log_level),
-            log_level=logging_config.log_level,
             access_log=False,
         )
-        self.logger.debug(f"Uvicorn config: {pformat(config.__dict__)}")
+        self.logger.debug(f"Uvicorn config:\n{pformat(config.__dict__)}")
         return config
 
     @property
@@ -55,11 +54,13 @@ class HttpEventService:
     @property
     @lru_cache(maxsize=1)
     def headers(self) -> list[tuple[str, str]] | None:
-        return [
+        headers = [
             ("server", f"{socket.gethostname()}"),
             ("x-app-name", project.name),
             ("x-app-version", str(project.version)),
         ]
+        self.logger.debug(f"Uvicorn headers:\n{pformat(headers)}")
+        return headers
 
     def apply_middlewares(self):
         self.fastapi_app.add_middleware(DeprecatedRouteMiddleware)

--- a/src/smib/events/services/http_event_service.py
+++ b/src/smib/events/services/http_event_service.py
@@ -21,7 +21,7 @@ class HttpEventService:
     def fastapi_app(self) -> FastAPI:
         root_path = webserver.path_prefix.rstrip('/')
         return FastAPI(
-            version=project.version,
+            version=str(project.version),
             title=project.display_name,
             description=project.description,
             root_path=root_path,
@@ -38,12 +38,14 @@ class HttpEventService:
             forwarded_allow_ips=webserver.forwarded_allow_ips,
             headers=self.headers,
             log_config=get_logging_config(logging_config.log_level),
+            log_level=logging_config.log_level,
             access_log=False,
         )
 
     @property
     @lru_cache(maxsize=1)
     def uvicorn_server(self) -> Server:
+        self.logger.warning(f"Starting uvicorn server with config: {self.uvicorn_config.__dict__}")
         return Server(config=self.uvicorn_config)
 
     @property
@@ -52,7 +54,7 @@ class HttpEventService:
         return [
             ("server", f"{socket.gethostname()}"),
             ("x-app-name", project.name),
-            ("x-app-version", project.version),
+            ("x-app-version", str(project.version)),
         ]
 
     def apply_middlewares(self):

--- a/src/smib/logging_/__init__.py
+++ b/src/smib/logging_/__init__.py
@@ -1,6 +1,8 @@
 import logging
 import logging.config
+
 from smib.utilities.environment import is_running_in_docker
+
 
 def get_logging_config(log_level: str = "DEBUG") -> dict:
     return {
@@ -44,7 +46,7 @@ def get_logging_config(log_level: str = "DEBUG") -> dict:
             },
             "pymongo": {
                 "level": "WARNING"
-            }
+            },
         },
     }
 

--- a/template.env
+++ b/template.env
@@ -7,6 +7,9 @@ SMIB_SLACK_APP_TOKEN=
 ## Slack Configuration
 #SMIB_SLACK_SIGNING_SECRET=
 
+## Environment Settings
+#SMIB_ENVIRONMENT=production
+
 ## Database Settings
 #SMIB_DB_MONGO_DB_HOST=localhost
 #SMIB_DB_MONGO_DB_PORT=27017

--- a/uv.lock
+++ b/uv.lock
@@ -446,6 +446,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -676,6 +685,7 @@ dependencies = [
     { name = "humanize" },
     { name = "jinja2" },
     { name = "makefun" },
+    { name = "packaging" },
     { name = "pydantic-settings" },
     { name = "pytz" },
     { name = "slack-bolt" },
@@ -698,6 +708,7 @@ requires-dist = [
     { name = "humanize", specifier = ">=4.14.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "makefun", specifier = ">=1.16.0,<2.0.0" },
+    { name = "packaging", specifier = ">=25.0" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
     { name = "pytz", specifier = ">=2025.2" },
     { name = "slack-bolt", specifier = ">=1.26.0,<2.0.0" },
@@ -719,14 +730,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.48.0"
+version = "0.49.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1a/608df0b10b53b0beb96a37854ee05864d182ddd4b1156a22f1ad3860425a/starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284", size = 2655031, upload-time = "2025-11-01T15:12:26.13Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e0/021c772d6a662f43b63044ab481dc6ac7592447605b5b35a957785363122/starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f", size = 74340, upload-time = "2025-11-01T15:12:24.387Z" },
 ]
 
 [[package]]
@@ -786,16 +797,16 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.35.3"
+version = "20.35.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/d5/b0ccd381d55c8f45d46f77df6ae59fbc23d19e901e2d523395598e5f4c93/virtualenv-20.35.3.tar.gz", hash = "sha256:4f1a845d131133bdff10590489610c98c168ff99dc75d6c96853801f7f67af44", size = 6002907, upload-time = "2025-10-10T21:23:33.178Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/28/e6f1a6f655d620846bd9df527390ecc26b3805a0c5989048c210e22c5ca9/virtualenv-20.35.4.tar.gz", hash = "sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c", size = 6028799, upload-time = "2025-10-29T06:57:40.511Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/73/d9a94da0e9d470a543c1b9d3ccbceb0f59455983088e727b8a1824ed90fb/virtualenv-20.35.3-py3-none-any.whl", hash = "sha256:63d106565078d8c8d0b206d48080f938a8b25361e19432d2c9db40d2899c810a", size = 5981061, upload-time = "2025-10-10T21:23:30.433Z" },
+    { url = "https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl", hash = "sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b", size = 6005095, upload-time = "2025-10-29T06:57:37.598Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Decouples version **display format** from git state by introducing environment-aware version formatting. The underlying version is still VCS-driven (git tags via `hatch-vcs`), but output format now varies by environment.

## What Changed
- Version stored internally as `packaging.version.Version` object
- Display format determined by `ENVIRONMENT` setting at runtime:
    - **PRODUCTION**: Base version only (strips post/dev/local suffixes)
    - **DEVELOPMENT**: Full version with local identifier
    - **TESTING**: Public version without local suffixes

## Example
Same git commit `2.2.1.post1.dev2+g1b9dd2138.d20251102125624` displays as:
- Production: `2.2.1`
- Development: `2.2.1.post1.dev2+g1b9dd2138.d20251102125624`
- Testing: `2.2.1.post1.dev2`
