### PR TITLE
Remove assignees and reviewers from renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,12 +14,6 @@
   "prConcurrentLimit": 2,
   "dependencyDashboard": true,
   "prCreation": "immediate",
-  "assignees": [
-    "sam57719"
-  ],
-  "reviewers": [
-    "sam57719"
-  ],
   "labels": ["dependencies"],
   "pruneStaleBranches": true,
   "packageRules": [


### PR DESCRIPTION
Removed specific assignees and reviewers from Renovate configuration.