### PR TITLE
Refactor plugin loading and imports for better modularity

### DIFF
--- a/src/plugins/space/smibhid/__init__.py
+++ b/src/plugins/space/smibhid/__init__.py
@@ -7,8 +7,8 @@ from smib.events.interfaces.scheduled_event_interface import ScheduledEventInter
 
 
 def register(api: ApiEventInterface, schedule: ScheduledEventInterface):
-    from .ui import register as register_ui_log_handlers
-    from .sensor import register as register_sensor_log_handlers
+    from plugins.space.smibhid.ui import register as register_ui_log_handlers
+    from plugins.space.smibhid.sensor import register as register_sensor_log_handlers
 
     register_ui_log_handlers(api)
     register_sensor_log_handlers(api, schedule)

--- a/src/plugins/space/spacestate/__init__.py
+++ b/src/plugins/space/spacestate/__init__.py
@@ -9,9 +9,9 @@ from smib.events.interfaces.websocket_event_interface import WebsocketEventInter
 
 
 def register(slack: AsyncApp, api: ApiEventInterface, ws: WebsocketEventInterface):
-    from .listeners.http import register as register_http_listeners
-    from .listeners.slack import register as register_slack_listeners
-    from .listeners.websocket import register as register_websocket_listeners
+    from plugins.space.spacestate.listeners.http import register as register_http_listeners
+    from plugins.space.spacestate.listeners.slack import register as register_slack_listeners
+    from plugins.space.spacestate.listeners.websocket import register as register_websocket_listeners
 
     register_http_listeners(api)
     register_slack_listeners(slack)

--- a/src/smib/plugins/integrations/http_plugin_integration.py
+++ b/src/smib/plugins/integrations/http_plugin_integration.py
@@ -6,7 +6,6 @@ from pprint import pformat
 
 from fastapi import APIRouter
 
-from smib.config import general
 from smib.events.interfaces.http import HttpEventInterface
 from smib.plugins.plugin import Plugin
 
@@ -22,7 +21,7 @@ class HttpPluginIntegration:
 
 
     def disconnect_plugin(self, plugin: Plugin):
-        self.logger.info(f"Locating and removing http routes in {plugin.unique_name} ({plugin.name})")
+        self.logger.info(f"Locating and removing http routes in {plugin.unique_name}")
         plugin_path = plugin.path
 
         module_path = Path(plugin.module.__file__)
@@ -55,7 +54,7 @@ class HttpPluginIntegration:
         router = self.http_event_interface.routers.get(plugin.unique_name)
         included_routes = any(route for route in router.routes if route.include_in_schema)
         if len(router.routes) == 0:
-            self.logger.debug(f"Removing unused router for {plugin.path.relative_to(general.plugins_directory)}")
+            self.logger.debug(f"Removing unused router for {plugin.unique_name}")
             self.http_event_interface.routers.pop(plugin.unique_name)
         if not included_routes:
             self.tag_metadata.remove(self.get_plugin_tags(plugin))

--- a/src/smib/plugins/integrations/http_plugin_integration.py
+++ b/src/smib/plugins/integrations/http_plugin_integration.py
@@ -33,7 +33,7 @@ class HttpPluginIntegration:
                 if hasattr(route.endpoint, '__module__') and route.endpoint.__module__ in sys.modules:
                     route_module_path = sys.modules[route.endpoint.__module__].__file__
                     if Path(route_module_path).resolve().is_relative_to(module_path):
-                        self.logger.debug(f"Removing route {route}")
+                        self.logger.debug(f"Removing route {route} from {plugin.unique_name}")
                         router.routes.remove(route)
 
     @staticmethod
@@ -54,7 +54,7 @@ class HttpPluginIntegration:
         router = self.http_event_interface.routers.get(plugin.unique_name)
         included_routes = any(route for route in router.routes if route.include_in_schema)
         if len(router.routes) == 0:
-            self.logger.debug(f"Removing unused router for {plugin.unique_name}")
+            self.logger.debug(f"Removing unused router for {plugin.unique_name} from {plugin.unique_name}")
             self.http_event_interface.routers.pop(plugin.unique_name)
         if not included_routes:
             self.tag_metadata.remove(self.get_plugin_tags(plugin))

--- a/src/smib/plugins/integrations/scheduled_plugin_integration.py
+++ b/src/smib/plugins/integrations/scheduled_plugin_integration.py
@@ -1,15 +1,11 @@
 import logging
 import sys
 from pathlib import Path
-from types import ModuleType
-from typing import Optional
 
 from apscheduler.job import Job
-from slack_bolt.app.async_app import AsyncApp
 
 from smib.events.interfaces.scheduled_event_interface import ScheduledEventInterface
-from smib.plugins.plugin import Plugin, PythonModulePlugin
-from smib.utilities.package import get_actual_module_name
+from smib.plugins.plugin import Plugin
 
 
 class ScheduledPluginIntegration:
@@ -18,7 +14,7 @@ class ScheduledPluginIntegration:
         self.logger: logging.Logger = logging.getLogger(self.__class__.__name__)
 
     def disconnect_plugin(self, plugin: Plugin):
-        self.logger.info(f"Locating and removing scheduled jobs in {plugin.unique_name} ({plugin.name})")
+        self.logger.info(f"Locating and removing scheduled jobs in {plugin.unique_name}")
 
         module_path = Path(plugin.module.__file__)
         if module_path.name == "__init__.py":

--- a/src/smib/plugins/integrations/slack_plugin_integration.py
+++ b/src/smib/plugins/integrations/slack_plugin_integration.py
@@ -1,15 +1,11 @@
 import logging
 import sys
 from pathlib import Path
-from types import ModuleType
-from typing import Optional
 
 from slack_bolt.app.async_app import AsyncApp
 from slack_bolt.middleware.async_custom_middleware import AsyncCustomMiddleware
-from slack_bolt.middleware.async_middleware import AsyncMiddleware
 
-from smib.plugins.plugin import Plugin, PythonModulePlugin
-from smib.utilities.package import get_actual_module_name
+from smib.plugins.plugin import Plugin
 
 
 class SlackPluginIntegration:
@@ -22,7 +18,7 @@ class SlackPluginIntegration:
         self.disconnect_middlewares(plugin)
 
     def disconnect_listeners(self, plugin: Plugin):
-        self.logger.info(f"Locating and removing slack listeners in {plugin.unique_name} ({plugin.name})")
+        self.logger.info(f"Locating and removing slack listeners in {plugin.unique_name}")
 
         module_path = Path(plugin.module.__file__)
         if module_path.name == "__init__.py":
@@ -36,7 +32,7 @@ class SlackPluginIntegration:
                     self.bolt_app._async_listeners.remove(listener)
 
     def disconnect_middlewares(self, plugin: Plugin):
-        self.logger.info(f"Locating and removing slack middleware in {plugin.unique_name} ({plugin.name})")
+        self.logger.info(f"Locating and removing slack middleware in {plugin.unique_name}")
 
         module_path = Path(plugin.module.__file__)
         if module_path.name == "__init__.py":

--- a/src/smib/plugins/integrations/slack_plugin_integration.py
+++ b/src/smib/plugins/integrations/slack_plugin_integration.py
@@ -28,7 +28,7 @@ class SlackPluginIntegration:
             if hasattr(listener.ack_function, '__module__') and listener.ack_function.__module__ in sys.modules:
                 listener_path = sys.modules[listener.ack_function.__module__].__file__
                 if Path(listener_path).resolve().is_relative_to(module_path):
-                    self.logger.debug(f"Removing listener {listener.ack_function.__name__}")
+                    self.logger.debug(f"Removing listener {listener.ack_function.__name__} from {plugin.unique_name}")
                     self.bolt_app._async_listeners.remove(listener)
 
     def disconnect_middlewares(self, plugin: Plugin):
@@ -46,5 +46,5 @@ class SlackPluginIntegration:
             if hasattr(middleware.func, '__module__') and middleware.func.__module__ in sys.modules:
                 middleware_path = sys.modules[middleware.func.__module__].__file__
                 if Path(middleware_path).resolve().is_relative_to(module_path):
-                    self.logger.debug(f"Removing middleware {middleware.func.__name__}")
+                    self.logger.debug(f"Removing middleware {middleware.func.__name__} from {plugin.unique_name}")
                     self.bolt_app._async_middleware_list.remove(middleware)

--- a/src/smib/plugins/integrations/websocket_plugin_integration.py
+++ b/src/smib/plugins/integrations/websocket_plugin_integration.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from fastapi import APIRouter
 
-from smib.config import general
 from smib.events.interfaces.websocket_event_interface import WebsocketEventInterface
 from smib.plugins.plugin import Plugin
 
@@ -18,7 +17,7 @@ class WebsocketPluginIntegration:
         self.logger: Logger = logging.getLogger(f"{self.__class__.__name__}")
 
     def disconnect_plugin(self, plugin: Plugin):
-        self.logger.info(f"Locating and removing websocket routes in {plugin.unique_name} ({plugin.name})")
+        self.logger.info(f"Locating and removing websocket routes in {plugin.unique_name}")
 
         module_path = Path(plugin.module.__file__)
         if module_path.name == "__init__.py":
@@ -40,7 +39,7 @@ class WebsocketPluginIntegration:
     def remove_router_if_unused(self, plugin: Plugin):
         router = self.websocket_event_interface.routers.get(plugin.unique_name)
         if len(router.routes) == 0:
-            self.logger.debug(f"Removing unused router for {plugin.path.relative_to(general.plugins_directory)}")
+            self.logger.debug(f"Removing unused router for {plugin.unique_name}")
             self.websocket_event_interface.routers.pop(plugin.unique_name)
 
 

--- a/src/smib/plugins/lifecycle_manager.py
+++ b/src/smib/plugins/lifecycle_manager.py
@@ -52,7 +52,7 @@ class PluginLifecycleManager:
                 self.unregister_plugin(plugin)
                 continue
             except Exception as e:
-                self.logger.exception(f"Failed to register plugin {plugin.unique_name}): {e}", exc_info=e)
+                self.logger.exception(f"Failed to register plugin {plugin.unique_name}: {e}", exc_info=e)
                 self.unregister_plugin(plugin)
                 continue
             else:

--- a/src/smib/plugins/lifecycle_manager.py
+++ b/src/smib/plugins/lifecycle_manager.py
@@ -2,16 +2,13 @@ import logging
 import sys
 from logging import Logger
 from pathlib import Path
-from types import ModuleType
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from slack_bolt.app.async_app import AsyncApp
 
 from smib.config import general
-from smib.plugins.plugin import Plugin
 from smib.plugins.loaders import PluginLoader, create_default_plugin_loader
-from smib.utilities.dynamic_caller import dynamic_caller
-from smib.utilities.package import get_actual_module_name
+from smib.plugins.plugin import Plugin
 
 
 class PluginLifecycleManager:
@@ -50,17 +47,16 @@ class PluginLifecycleManager:
                 self.preregister_plugin(plugin)
                 self.register_plugin(plugin)
                 self.postregister_plugin(plugin)
-
-                self.logger.info(f"Registered plugin {plugin.unique_name} ({self.get_relative_path(plugin.path)})")
             except AssertionError as e:
-                self.logger.error(f"Failed to register plugin {plugin.unique_name} ({self.get_relative_path(plugin.path)}): {e}")
+                self.logger.error(f"Failed to register plugin {plugin.unique_name}: {e}")
                 self.unregister_plugin(plugin)
                 continue
             except Exception as e:
-                self.logger.exception(f"Failed to register plugin {plugin.unique_name} ({self.get_relative_path(plugin.path)}): {e}", exc_info=e)
+                self.logger.exception(f"Failed to register plugin {plugin.unique_name}): {e}", exc_info=e)
                 self.unregister_plugin(plugin)
                 continue
-
+            else:
+                self.logger.info(f"Registered plugin {plugin.unique_name}")
         self.logger.info(f"Registered {len(self.plugins)} plugin(s) ({self.plugin_string})")
 
     def register_plugin(self, plugin: Plugin):
@@ -108,7 +104,7 @@ class PluginLifecycleManager:
             if self.validate_plugin(plugin):
                 valid_plugins.append(plugin)
             else:
-                self.logger.info(f'{plugin.unique_name} ({self.get_relative_path(plugin.path)}) is invalid... removing')
+                self.logger.info(f'{plugin.unique_name} is invalid... removing')
                 continue
 
         return valid_plugins
@@ -118,23 +114,23 @@ class PluginLifecycleManager:
         self.logger.debug(f"Validating plugin {plugin.unique_name}")
         # All plugins must have metadata with display_name and description
         if not plugin.metadata.display_name or not plugin.metadata.description:
-            self.logger.warning(f'{plugin.unique_name} ({plugin.name}) does not have required metadata (display_name, description)')
+            self.logger.warning(f'{plugin.unique_name} does not have required metadata (display_name, description)')
             return False
 
         # All plugins must have a register method
         if not hasattr(plugin, 'register'):
-            self.logger.info(f'{plugin.unique_name} ({plugin.name}) does not have a register method')
+            self.logger.info(f'{plugin.unique_name} does not have a register method')
             return False
 
         # Log if recommended metadata is missing
         if not plugin.metadata.author:
-            self.logger.info(f'{plugin.unique_name} ({plugin.name}) does not have the recommended author metadata')
+            self.logger.info(f'{plugin.unique_name} does not have the recommended author metadata')
 
         return True
 
     @property
     def plugin_string(self):
-        return ", ".join(str(self.get_relative_path(plugin.path)) for plugin in self.plugins) or "None"
+        return ", ".join(plugin.unique_name for plugin in self.plugins) or "None"
 
     def register_plugin_unregister_callback(self, callback: callable):
         self.plugin_unregister_callbacks.append(callback)

--- a/src/smib/plugins/loaders/plugin_loaders.py
+++ b/src/smib/plugins/loaders/plugin_loaders.py
@@ -9,7 +9,6 @@ import importlib.util
 import logging
 import sys
 from pathlib import Path
-from types import ModuleType
 from typing import List, Optional, Protocol
 
 from smib.plugins.plugin import Plugin, PythonModulePlugin
@@ -40,7 +39,7 @@ class PythonModulePluginLoader:
     def load_from_path(self, path: Path, name: Optional[str] = None) -> Plugin:
         """Load a plugin from a .py file."""
         path = path.resolve()
-        module_name = name or path.with_suffix('').name
+        module_name = name or f"{path.parent.name}.{path.with_suffix('').name}"
 
         # Ensure the module is a .py file
         if not path.suffix == ".py":
@@ -96,7 +95,7 @@ class PythonPackagePluginLoader:
     def load_from_path(self, path: Path, name: Optional[str] = None) -> Plugin:
         """Load a plugin from a directory with an __init__.py file."""
         path = path.resolve()
-        package_name = name or path.name
+        package_name = name or f"{path.parent.name}.{path.name}"
 
         # Ensure the package contains an __init__.py file
         init_file = path / '__init__.py'


### PR DESCRIPTION
### Description

To allow plugins such as
`space/spacestate` and `metrics/spacestate` to be loaded and working at the same time

- Implemented parent-folder namespacing (e.g., `category.name`) in `PythonModulePluginLoader` and `PythonPackagePluginLoader` to ensure unique module registration in `sys.modules`.
- Converted relative imports in the `spacestate` and `smibhid` plugins to fully qualified absolute imports, resolving `ModuleNotFound` errors during dynamic registration.
- Simplified logging in `LifecycleManager` and `Integration` by prioritizing `unique_name` over redundant file paths.
- Enhanced error handling and logging for greater clarity in the plugin registration lifecycle.